### PR TITLE
EZP-31354: Added SiteAccess parameter to Shell Jobs created by CronjobRegistry

### DIFF
--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -6,3 +6,4 @@ services:
         class: '%ezplatform.cron.registry.cronjobs.class%'
         arguments:
             - '%kernel.environment%'
+            - '@ezpublish.siteaccess'


### PR DESCRIPTION
This PR fixes `ezplatform:cron:run` command, so `--siteaccess` parameter passed to it is not lost, when shell jobs are run.

More in JIRA ticket: https://jira.ez.no/browse/EZP-31354