### PR TITLE
EZP-31958: Allow console command specific extra options

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The tag takes the following arguments:
 - `name`: `ezplatform.cron.job`
 - `schedule`: _Takes any kind of [format supported by cron/cron](https://github.com/Cron/Cron#crontab-syntax), which mimics linux crontab format. E.g. `* * * * *`_
 - `category`: _(Optional, by default: `default`) Lets you separate cronjobs that should be run under different logic then default, e.g. infrequent jobs (NOTE: Means end user will need to setup several entries in his crontab to run all categories!)_
-- `params`: _(Optional, by default: `''`) Takes custom parameter/s in string format which are added to the command. (E.g. '--keep=0 --status=draft' for running the cleanup versions command)_
+- `options`: _(Optional, by default: `''`) Takes custom option/s in string format which are added to the command. (E.g. '--keep=0 --status=draft' for running the cleanup versions command)_
 
 
 ### Example

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The tag takes the following arguments:
 - `name`: `ezplatform.cron.job`
 - `schedule`: _Takes any kind of [format supported by cron/cron](https://github.com/Cron/Cron#crontab-syntax), which mimics linux crontab format. E.g. `* * * * *`_
 - `category`: _(Optional, by default: `default`) Lets you separate cronjobs that should be run under different logic then default, e.g. infrequent jobs (NOTE: Means end user will need to setup several entries in his crontab to run all categories!)_
+- `params`: _(Optional, by default: `''`) Takes custom parameter/s in string format which are added to the command. (E.g. '--keep=0 --status=draft' for running the cleanup versions command)_
 
 
 ### Example

--- a/src/bundle/DependencyInjection/Compiler/CronJobCompilerPass.php
+++ b/src/bundle/DependencyInjection/Compiler/CronJobCompilerPass.php
@@ -47,7 +47,7 @@ class CronJobCompilerPass implements CompilerPassInterface
                     $reference,
                     $cronJob['schedule'],
                     $cronJob['category'],
-                    $cronJob['options'],
+                    $cronJob['options'] ?? '',
                 ]);
             }
         }

--- a/src/bundle/DependencyInjection/Compiler/CronJobCompilerPass.php
+++ b/src/bundle/DependencyInjection/Compiler/CronJobCompilerPass.php
@@ -39,10 +39,15 @@ class CronJobCompilerPass implements CompilerPassInterface
                     ? $cronJob['category']
                     : CronJobsRegistry::DEFAULT_CATEGORY;
 
+                $cronJob['params'] = isset($cronJob['params'])
+                    ? ' '.$cronJob['params']
+                    : '';
+
                 $registry->addMethodCall('addCronJob', [
                     $reference,
                     $cronJob['schedule'],
                     $cronJob['category'],
+                    $cronJob['params'],
                 ]);
             }
         }

--- a/src/bundle/DependencyInjection/Compiler/CronJobCompilerPass.php
+++ b/src/bundle/DependencyInjection/Compiler/CronJobCompilerPass.php
@@ -39,15 +39,15 @@ class CronJobCompilerPass implements CompilerPassInterface
                     ? $cronJob['category']
                     : CronJobsRegistry::DEFAULT_CATEGORY;
 
-                $cronJob['params'] = isset($cronJob['params'])
-                    ? ' '.$cronJob['params']
+                $cronJob['options'] = isset($cronJob['options'])
+                    ? ' '.$cronJob['options']
                     : '';
 
                 $registry->addMethodCall('addCronJob', [
                     $reference,
                     $cronJob['schedule'],
                     $cronJob['category'],
-                    $cronJob['params'],
+                    $cronJob['options'],
                 ]);
             }
         }

--- a/src/bundle/DependencyInjection/Compiler/CronJobCompilerPass.php
+++ b/src/bundle/DependencyInjection/Compiler/CronJobCompilerPass.php
@@ -39,10 +39,6 @@ class CronJobCompilerPass implements CompilerPassInterface
                     ? $cronJob['category']
                     : CronJobsRegistry::DEFAULT_CATEGORY;
 
-                $cronJob['options'] = isset($cronJob['options'])
-                    ? ' '.$cronJob['options']
-                    : '';
-
                 $registry->addMethodCall('addCronJob', [
                     $reference,
                     $cronJob['schedule'],

--- a/src/bundle/Registry/CronJobsRegistry.php
+++ b/src/bundle/Registry/CronJobsRegistry.php
@@ -36,6 +36,11 @@ class CronJobsRegistry
      */
     protected $siteaccess;
 
+    /**
+     * @var string
+     */
+    protected $params;
+
     public function __construct(string $environment, SiteAccess $siteaccess)
     {
         $finder = new PhpExecutableFinder();
@@ -45,12 +50,13 @@ class CronJobsRegistry
         $this->siteaccess = $siteaccess;
     }
 
-    public function addCronJob(Command $command, string $schedule = null, string $category = self::DEFAULT_CATEGORY): void
+    public function addCronJob(Command $command, string $schedule = null, string $category = self::DEFAULT_CATEGORY, string $params = ''): void
     {
-        $command = sprintf('%s %s %s --siteaccess=%s --env=%s',
+        $command = sprintf('%s %s %s%s --siteaccess=%s --env=%s',
             $this->executable,
             $_SERVER['SCRIPT_NAME'],
             $command->getName(),
+            $params,
             $this->siteaccess->name,
             $this->environment
         );

--- a/src/bundle/Registry/CronJobsRegistry.php
+++ b/src/bundle/Registry/CronJobsRegistry.php
@@ -39,7 +39,7 @@ class CronJobsRegistry
     /**
      * @var string
      */
-    protected $params;
+    protected $options;
 
     public function __construct(string $environment, SiteAccess $siteaccess)
     {
@@ -50,13 +50,13 @@ class CronJobsRegistry
         $this->siteaccess = $siteaccess;
     }
 
-    public function addCronJob(Command $command, string $schedule = null, string $category = self::DEFAULT_CATEGORY, string $params = ''): void
+    public function addCronJob(Command $command, string $schedule = null, string $category = self::DEFAULT_CATEGORY, string $options = ''): void
     {
         $command = sprintf('%s %s %s%s --siteaccess=%s --env=%s',
             $this->executable,
             $_SERVER['SCRIPT_NAME'],
             $command->getName(),
-            $params,
+            $options,
             $this->siteaccess->name,
             $this->environment
         );

--- a/src/bundle/Registry/CronJobsRegistry.php
+++ b/src/bundle/Registry/CronJobsRegistry.php
@@ -52,7 +52,7 @@ class CronJobsRegistry
 
     public function addCronJob(Command $command, string $schedule = null, string $category = self::DEFAULT_CATEGORY, string $options = ''): void
     {
-        $command = sprintf('%s %s %s%s --siteaccess=%s --env=%s',
+        $command = sprintf('%s %s %s %s --siteaccess=%s --env=%s',
             $this->executable,
             $_SERVER['SCRIPT_NAME'],
             $command->getName(),


### PR DESCRIPTION
Allow console command specific extra options (#12 )

The config for cleanup versions cronjob would look like this:
```
    ezplatform.cron.cleanup_version:
        class: eZ\Bundle\EzPublishCoreBundle\Command\CleanupVersionsCommand
        tags:
            - { name: console.command }
            - { name: ezplatform.cron.job, schedule: '55 23 3 1-12 *', category: 'monthly', options: '--keep=0 --status=draft' }
```