### PR TITLE
EZP-32134: Setting siteaccess for cronjob via tag argument

### DIFF
--- a/src/bundle/Registry/CronJobsRegistry.php
+++ b/src/bundle/Registry/CronJobsRegistry.php
@@ -52,14 +52,25 @@ class CronJobsRegistry
 
     public function addCronJob(Command $command, string $schedule = null, string $category = self::DEFAULT_CATEGORY, string $options = ''): void
     {
-        $command = sprintf('%s %s %s %s --siteaccess=%s --env=%s',
-            $this->executable,
-            $_SERVER['SCRIPT_NAME'],
-            $command->getName(),
-            $options,
-            $this->siteaccess->name,
-            $this->environment
-        );
+        if (strpos($options,'--siteaccess') === false) {
+            $command = sprintf('%s %s %s %s --siteaccess=%s --env=%s',
+                $this->executable,
+                $_SERVER['SCRIPT_NAME'],
+                $command->getName(),
+                $options,
+                $this->siteaccess->name,
+                $this->environment
+            );
+        }
+        else {
+            $command = sprintf('%s %s %s %s --env=%s',
+                $this->executable,
+                $_SERVER['SCRIPT_NAME'],
+                $command->getName(),
+                $options,
+                $this->environment
+            );
+        }
 
         $job = new ShellJob();
         $job->setSchedule(new CrontabSchedule($schedule));


### PR DESCRIPTION
With this improvement it will be possible to set the siteaccess for a cronjob via the options argument of service tag.

https://issues.ibexa.co/projects/EZP/issues/EZP-32134