### PR TITLE
IBX-394: Added lazy to registry cronjobs service

### DIFF
--- a/src/bundle/Resources/config/services.yaml
+++ b/src/bundle/Resources/config/services.yaml
@@ -8,6 +8,7 @@ services:
 
     ezplatform.cron.registry.cronjobs:
         class: '%ezplatform.cron.registry.cronjobs.class%'
+        lazy: true
         arguments:
             - '%kernel.environment%'
             - '@ezpublish.siteaccess'


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-394](https://issues.ibexa.co/browse/IBX-394)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no
| **Doc needed**                       | no

After changed ConsoleCommandListener subscription from MVCEvents::CONSOLE_INIT to  ConsoleEvents::COMMAND CronJobsRegistry is not take siteaccess from ConsoleCommandListener

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Checked that target branch is set correctly.